### PR TITLE
Export LogMessageMatch.Matches()

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -209,7 +209,9 @@ type LogMessageMatch struct {
 	AllAttrsMatch bool
 }
 
-func (lmm LogMessageMatch) matches(lm LogMessage) bool {
+// Matches returnes true if the provided LogMessage satisfies
+// LogMessageMatch.
+func (lmm LogMessageMatch) Matches(lm LogMessage) bool {
 	if lmm.Message != lm.Message {
 		return false
 	}


### PR DESCRIPTION
Enables behavior similar AssertPrecise() but have the user handle the error scenario instead of having slogassert do it via Fail().